### PR TITLE
Fix Applicative instance for Moi

### DIFF
--- a/ch23/ch23_23.6_1.hs
+++ b/ch23/ch23_23.6_1.hs
@@ -28,6 +28,5 @@ instance Monad (Moi s) where
   (>>=) :: Moi s a
         -> (a -> Moi s b)
         -> Moi s b
-  (Moi f) >>= g = Moi $ \s -> let a = fst $ f s
-                                  ms = runMoi $ g a
-                              in ms s
+  (Moi f) >>= g = Moi $ \s -> let (a, s') = f s
+                              in runMoi (g a) s'

--- a/ch23/ch23_23.6_1.hs
+++ b/ch23/ch23_23.6_1.hs
@@ -18,9 +18,9 @@ instance Applicative (Moi s) where
   (<*>) :: Moi s (a -> b)
         -> Moi s a
         -> Moi s b
-  (Moi f) <*> (Moi g) = Moi $ \s -> let fab = fst $ f s
-                                        (a, b) = g s
-                                    in (fab a, b)  
+  (Moi f) <*> (Moi g) = Moi $ \s -> let (fab, s') = f s
+                                        (a, b) = g s'
+                                    in (fab a, b)
 
 instance Monad (Moi s) where
   return = pure


### PR DESCRIPTION
The original solution ignores potential state changes performed by the left-hand side argument to `<*>`. The correct implementation does not discard it - instead, it captures it (as `s'` in my code below) and passes it on instead of the original `s` to the function in the right-side argument. The resulting state is then what gets returned in the final tuple.

PS: thanks for putting this repo together, it's great for sanity checking my solutions :)